### PR TITLE
add grad checkpointing

### DIFF
--- a/main_mar.py
+++ b/main_mar.py
@@ -62,6 +62,7 @@ def get_args_parser():
     parser.add_argument('--weight_decay', type=float, default=0.02,
                         help='weight decay (default: 0.02)')
 
+    parser.add_argument('--grad_checkpointing', action='store_true')
     parser.add_argument('--lr', type=float, default=None, metavar='LR',
                         help='learning rate (absolute lr)')
     parser.add_argument('--blr', type=float, default=1e-4, metavar='LR',
@@ -203,6 +204,7 @@ def main(args):
         diffloss_w=args.diffloss_w,
         num_sampling_steps=args.num_sampling_steps,
         diffusion_batch_mul=args.diffusion_batch_mul,
+        grad_checkpointing=args.grad_checkpointing,
     )
 
     print("Model = %s" % str(model))


### PR DESCRIPTION
Add gradient checkpointing to save GPU memory. At a slight cost to training speed, using checkpointing can drastically reduce GPU memory usage.

Tested on 8 80G A100 GPUs:
- MAR-L, diffloss_d 8, diffloss_w 1280: from ~62GB to ~32GB, with the training time increasing from 0.78s/iter to 0.94s/iter.
- MAR-H, diffloss_d 12, diffloss_w 1536: from Out of Memory (OOM) to ~44GB, with the training time around 1.56s/iter.

The global batch size is 8x64=512